### PR TITLE
feat: leverage claude code action with `agent` mode

### DIFF
--- a/.github/workflows/technical-review.yml
+++ b/.github/workflows/technical-review.yml
@@ -39,8 +39,9 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Review code submission
-        uses: textlayer/claude-code-action@v1.1
+        uses: anthropics/claude-code-action@beta
         with:
+          mode: agent
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ steps.app-token.outputs.token }}
           direct_prompt: ${{ vars.BACKEND_INTERVIEW_PROMPT }}


### PR DESCRIPTION
Uses Claude Code's official Anthropic Github action with `mode: agent` for automation scenarios.

Allows us to maintain parity with the official Action's repo and move away from a hacky internal fork.